### PR TITLE
Piecemeal improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-﻿## 0.2.8
+﻿## 0.2.9:
+* Get-Extension:
+   * -CouldRun now honors validation attributes (#77)
+   * -CouldPipe now honors validation attributes (#78)
+   * -ExtensionName now supports Regex Literal Aliases ```[Alias(/Expression/)]``` (#80)
+   * -CouldRun, -CouldPipe, -Validate are no longer mutually exclusive (#79)
+* Install-Piecemeal
+   * Support for custom -WhereObject (#73)            
+   * Support for custom -ForeachObject (#74)
+---
+
+## 0.2.8
 * Get-Extension:  
   * Performance Improvements (#75)
   * Regular Expressions now IgnorePatternWhitespace (#71)

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -52,8 +52,14 @@
     [ValidateNotNullOrEmpty()]
     [string[]]
     $ExtensionName,
+    
+    <#
 
-    # If provided, will treat -ExtensionName as a wildcard.
+    If provided, will treat -ExtensionName as a wildcard.
+    This will return any extension whose name, displayname, or aliases are like the -ExtensionName.
+
+    If the extension has an Alias with a regular expression literal, then extension name will be valid if that regular expression matches.
+    #>
     [Parameter(ValueFromPipelineByPropertyName)]
     [switch]
     $Like,

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -597,7 +597,6 @@
                     }
                 }
 
-
                 if ($DynamicParameter -or $DynamicParameterSetName -or $DynamicParameterPositionOffset -or $NoMandatoryDynamicParameter) {
                     $extensionParams = $extCmd.GetDynamicParameters($DynamicParameterSetName, $DynamicParameterPositionOffset, $NoMandatoryDynamicParameter, $CommandName)
                     foreach ($kv in $extensionParams.GetEnumerator()) {
@@ -789,8 +788,14 @@
                 Where-Object { $_.Name -Match $extensionFullRegex } |
                 ConvertToExtension |
                 . WhereExtends $CommandName |
+                #region Install-Piecemeal -WhereObject
+                # This section can be updated by using Install-Piecemeal -WhereObject
+                #endregion Install-Piecemeal -WhereObject
                 Sort-Object Rank, Name |
                 OutputExtension
+                #region Install-Piecemeal -ForeachObject
+                # This section can be updated by using Install-Piecemeal -ForeachObject
+                #endregion Install-Piecemeal -ForeachObject
         } else {
             $script:Extensions |
                 . WhereExtends $CommandName |

--- a/Piecemeal.HelpOut.ps1
+++ b/Piecemeal.HelpOut.ps1
@@ -8,6 +8,5 @@ if ($piecemealLoaded) {
     "::error:: Piecemeal not loaded" |Out-Host
 }
 if ($piecemealLoaded) {
-    Save-MarkdownHelp -Module $piecemealLoaded.Name -PassThru |
-        Add-Member ScriptProperty CommitMessage {"Updating $($this.Name)" } -Force -PassThru
+    Save-MarkdownHelp -Module $piecemealLoaded.Name -PassThru
 }

--- a/Piecemeal.psd1
+++ b/Piecemeal.psd1
@@ -1,5 +1,5 @@
 ﻿@{
-    ModuleVersion    = '0.2.8'
+    ModuleVersion    = '0.2.9'
     RootModule       = 'Piecemeal.psm1'
     Description      = 'Easy Extensible Plugins for PowerShell'
     GUID             = '91e2c328-d7dc-44a3-aeeb-ef3b19c36767'
@@ -13,6 +13,17 @@
               ProjectURI   = 'https://github.com/StartAutomating/Piecemeal'
               LicenseURI   = 'https://github.com/StartAutomating/Piecemeal/blob/main/LICENSE'
               ReleaseNotes = @'
+## 0.2.9:
+* Get-Extension:
+   * -CouldRun now honors validation attributes (#77)
+   * -CouldPipe now honors validation attributes (#78)
+   * -ExtensionName now supports Regex Literal Aliases ```[Alias(/Expression/)]``` (#80)
+   * -CouldRun, -CouldPipe, -Validate are no longer mutually exclusive (#79)
+* Install-Piecemeal
+   * Support for custom -WhereObject (#73)            
+   * Support for custom -ForeachObject (#74)
+---
+
 ## 0.2.8
 * Get-Extension:  
   * Performance Improvements (#75)

--- a/Piecemeal.tests.ps1
+++ b/Piecemeal.tests.ps1
@@ -189,6 +189,11 @@ describe Piecemeal {
             $ext.ExtensionCommand.DisplayName | Should -belike 08*
         }
 
+        it 'Will respect parameter validation attributes' {            
+            $ext = Get-Extension -ExtensionPath $pwd -ExtensionName 08* -Like -CouldRun -Parameter @{Verb='BadVerb'} -CouldPipe (Get-Process -id $pid)
+            $ext | Should -be $null
+        }
+
         it 'Can keep the parameter set when getting -DynamicParameter' {
             $dp  = Get-Extension -ExtensionPath $pwd -ExtensionName 06* -Like -DynamicParameter
             $dp.Values |

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ Piecemeal is a little PowerShell module that helps solve a big problem:  allowin
 
 Piecemeal standardizes the creation of PowerShell extension scripts, and provides an embeddable engine for extensibility.
 
-### Embedding Piecemeal
-
 #### Installing Piecemeal
 
 You can embed Piecemeal by using Install-Piecemeal:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,4 +1,15 @@
-﻿## 0.2.8
+﻿## 0.2.9:
+* Get-Extension:
+   * -CouldRun now honors validation attributes (#77)
+   * -CouldPipe now honors validation attributes (#78)
+   * -ExtensionName now supports Regex Literal Aliases ```[Alias(/Expression/)]``` (#80)
+   * -CouldRun, -CouldPipe, -Validate are no longer mutually exclusive (#79)
+* Install-Piecemeal
+   * Support for custom -WhereObject (#73)            
+   * Support for custom -ForeachObject (#74)
+---
+
+## 0.2.8
 * Get-Extension:  
   * Performance Improvements (#75)
   * Regular Expressions now IgnorePatternWhitespace (#71)

--- a/docs/Get-Extension.md
+++ b/docs/Get-Extension.md
@@ -66,7 +66,10 @@ By default, '(extension|ext|ex|x)\.ps1$'
 ---
 #### **ExtensionName**
 
-The name of an extension
+The name of an extension.
+By default, this will match any extension command whose name, displayname, or aliases exactly match the name.
+
+If the extension has an Alias with a regular expression literal, then extension name will be valid if that regular expression matches.
 
 
 
@@ -77,6 +80,9 @@ The name of an extension
 #### **Like**
 
 If provided, will treat -ExtensionName as a wildcard.
+This will return any extension whose name, displayname, or aliases are like the -ExtensionName.
+
+If the extension has an Alias with a regular expression literal, then extension name will be valid if that regular expression matches.
 
 
 

--- a/docs/Get-Extension.md
+++ b/docs/Get-Extension.md
@@ -69,7 +69,7 @@ By default, '(extension|ext|ex|x)\.ps1$'
 The name of an extension.
 By default, this will match any extension command whose name, displayname, or aliases exactly match the name.
 
-If the extension has an Alias with a regular expression literal, then extension name will be valid if that regular expression matches.
+If the extension has an Alias with a regular expression literal (```'/Expression/'```) then the -ExtensionName will be valid if that regular expression matches.
 
 
 
@@ -93,6 +93,9 @@ If the extension has an Alias with a regular expression literal, then extension 
 #### **Match**
 
 If provided, will treat -ExtensionName as a regular expression.
+This will return any extension whose name, displayname, or aliases match the -ExtensionName.
+
+If the extension has an Alias with a regular expression literal, then extension name will be valid if that regular expression matches.
 
 
 

--- a/docs/Install-Piecemeal.md
+++ b/docs/Install-Piecemeal.md
@@ -136,6 +136,26 @@ If provided, will rename variables.
 |-------------------|--------|-------|---------------------|
 |```[IDictionary]```|false   |8      |true (ByPropertyName)|
 ---
+#### **ForeachObject**
+
+A custom Foreach-Object that will be appended to main pipelines within Get-Extension.
+
+
+
+|Type                 |Requried|Postion|PipelineInput|
+|---------------------|--------|-------|-------------|
+|```[ScriptBlock[]]```|false   |9      |false        |
+---
+#### **WhereObject**
+
+A custom Where-Object that will be injected to the main pipelines within Get-Extension
+
+
+
+|Type                 |Requried|Postion|PipelineInput|
+|---------------------|--------|-------|-------------|
+|```[ScriptBlock[]]```|false   |10     |false        |
+---
 ### Outputs
 System.String
 
@@ -143,7 +163,7 @@ System.String
 ---
 ### Syntax
 ```PowerShell
-Install-Piecemeal [[-ExtensionModule] <String>] [[-Verb] <String[]>] [[-ExtensionModuleAlias] <String[]>] [[-ExtensionPattern] <String[]>] [[-ExtensionTypeName] <String>] [[-ExtensionNoun] <String>] [-RequireExtensionAttribute] [-RequireCmdletAttribute] [[-OutputPath] <String>] [[-RenameVariable] <IDictionary>] [<CommonParameters>]
+Install-Piecemeal [[-ExtensionModule] <String>] [[-Verb] <String[]>] [[-ExtensionModuleAlias] <String[]>] [[-ExtensionPattern] <String[]>] [[-ExtensionTypeName] <String>] [[-ExtensionNoun] <String>] [-RequireExtensionAttribute] [-RequireCmdletAttribute] [[-OutputPath] <String>] [[-RenameVariable] <IDictionary>] [[-ForeachObject] <ScriptBlock[]>] [[-WhereObject] <ScriptBlock[]>] [<CommonParameters>]
 ```
 ---
 ### Notes

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,8 +6,6 @@ Piecemeal is a little PowerShell module that helps solve a big problem:  allowin
 
 Piecemeal standardizes the creation of PowerShell extension scripts, and provides an embeddable engine for extensibility.
 
-### Embedding Piecemeal
-
 #### Installing Piecemeal
 
 You can embed Piecemeal by using Install-Piecemeal:

--- a/en-us/about_Piecemeal.help.txt
+++ b/en-us/about_Piecemeal.help.txt
@@ -6,8 +6,6 @@ Piecemeal is a little PowerShell module that helps solve a big problem:  allowin
 
 Piecemeal standardizes the creation of PowerShell extension scripts, and provides an embeddable engine for extensibility.
 
-### Embedding Piecemeal
-
 #### Installing Piecemeal
 
 You can embed Piecemeal by using Install-Piecemeal:


### PR DESCRIPTION
## 0.2.9:
* Get-Extension:
   * -CouldRun now honors validation attributes (#77)
   * -CouldPipe now honors validation attributes (#78)
   * -ExtensionName now supports Regex Literal Aliases ```[Alias(/Expression/)]``` (#80)
   * -CouldRun, -CouldPipe, -Validate are no longer mutually exclusive (#79)
* Install-Piecemeal
   * Support for custom -WhereObject (#73)            
   * Support for custom -ForeachObject (#74)
---