### PR TITLE
Piecemeal@0.3.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,32 @@
-﻿## 0.3.8:
+﻿## Piecemeal@0.3.9:
+
+* Allowing any command to be an extension! (Fixes #120)
+
+Functions, Cmdlets, and Aliases that meet the the naming convention will be seen as extensions by Get-Extension.
+
+In most cases, this allows extensions to be defined in memory or on disk.
+
+* Allowing .DisplayName to be set (Fixes #123)
+* Adding .CouldPipeType to all extensions (Fixes #121)
+* Not allowing a directories to be extensions (for now) (Fixes #125)
+* Not clearing an extension's .PSTypeNames (inserting instead) (Fixes #126)
+
+---
+
+## Piecemeal@0.3.8:
 
 * Adding .HasValidation to all extensions (Fixes #117)
 * All extension methods and properties are now prevalidated in case of collision (Fixes #118)
 
 ---
 
-## 0.3.7:
+## Piecemeal@0.3.7:
 
 * Get-Extension:  Stringifying input for ValidatePattern (Fixes #114)
 
 ---
 
-## 0.3.6:
+## Piecemeal@0.3.6:
 
 * Get-Extension -CouldPipe can now handle PSTypeName attributes (Fixes #109)
 * Piecemeal action no longer produces output variables (Fixes #110)
@@ -19,12 +34,12 @@
 
 ---
 
-## 0.3.5:
+## Piecemeal@0.3.5:
 * GitHub Action now checks if it is on a branch (Fixes #107)
 
 ---
 
-## 0.3.4:
+## Piecemeal@0.3.4:
 * Get-Extension
   * Adding -Force (Fixes #103)
   * Caching allCommands (Fixes #104)
@@ -32,13 +47,13 @@
 
 ---
 
-## 0.3.3:
+## Piecemeal@0.3.3:
 * Consolidating -Help parameters (#101)
 * Fixing .GetHelpField (#100)
 
 ---
 
-## 0.3.2:
+## Piecemeal@0.3.2:
 * Piecemeal Available as a GitHub Action (#56)
 * Get-Extension:
   * Adding .BlockComments property (#96)
@@ -50,7 +65,7 @@
 
 ---
 
-## 0.3.1:
+## Piecemeal@0.3.1:
 * Get-Extension:
    * New Properties/Methods for Each Extension
      * .Category (#89)
@@ -62,19 +77,19 @@
 
 ---
 
-## 0.3.0:
+## Piecemeal@0.3.0:
 * Get-Extension:
   * Ensuring Regexes IgnoreCase (#85)
   * Trimming Trailing Whitepace from .Synopsis and .Description (#84)
 
 ---  
 
-## 0.2.9.1:
+## Piecemeal@0.2.9.1:
 * Fixing Get-Extension overcollection (#82)
 
 ---
 
-## 0.2.9:
+## Piecemeal@0.2.9:
 * Get-Extension:
    * -CouldRun now honors validation attributes (#77)
    * -CouldPipe now honors validation attributes (#78)
@@ -86,7 +101,7 @@
 
 ---
 
-## 0.2.8
+## Piecemeal@0.2.8
 * Get-Extension:  
   * Performance Improvements (#75)
   * Regular Expressions now IgnorePatternWhitespace (#71)
@@ -98,14 +113,14 @@
 
 ---
 
-## 0.2.7
+## Piecemeal@0.2.7
 * Get-Extension
   * Allowing any command type (#65)
   * Fixing -CouldPipe (#67)
 
 ---
 
-## 0.2.6
+## Piecemeal@0.2.6
 * Get-Extension:
   * Matching -ExtensionName support aliases (#63)
   * Matching -ExtensionName against .DisplayName or .Name (#61)
@@ -113,25 +128,25 @@
 
 ---
 
-## 0.2.5
+## Piecemeal@0.2.5
 * Get-Extension:  Adding -CouldPipe (#58)
 * Get-Extension:  Fixing .Tags based inclusion (#57)
 
 ---
 
-## 0.2.4
+## Piecemeal@0.2.4
 * Install-Piecemeal:  Making -ExtensionModule Optional (#54)
 
 ---
 
-## 0.2.3
+## Piecemeal@0.2.3
 * Adding New-Extension (#51)
 * Generating Docs (#52)
 * Allowing New-Extension to be installed with Install-Piecemeal
 
 ---
 
-## 0.2.2
+## Piecemeal@0.2.2
 * Adding test for [ValidateScript] (#47)
 * Updating Piecemeal tests (checking validation order) (#48)
 * Get-Extension:  Fixing -ValidateInput logic (#48)
@@ -139,7 +154,7 @@
 
 ---
 
-## 0.2.1
+## Piecemeal@0.2.1
 * Get-Extension:  Support for -AllValid (#45)
 * Get-Extension:  Removing Validation Errors when -ErrorAction is ignore (#43)
 * Updating Piecemeal tests: Adding test for Steppable Pipeline (#42)
@@ -148,7 +163,7 @@
 
 ---
 
-## 0.2
+## Piecemeal@0.2
 * Adding formatting for extensions (#40)
 * Updating Piecemeal tests (account for Regex) (#39)
 * Get-Extension:  Regex support for [Cmdlet] attribute (#39)
@@ -157,35 +172,35 @@
 
 ---
 
-## 0.1.10
+## Piecemeal@0.1.10
 * Get-Extension:  Adding -ParameterSetName (#36)
 * Install-Extension:  Adding -Force to Import-Module in Install Note (#32)
 
 ---
 
-## 0.1.9
+## Piecemeal@0.1.9
 * Get-Extension: Fixing CouldRun/Run issue with multiple ParameterSets (with other attributes present) (#31)
 
 ---
 
-## 0.1.8
+## Piecemeal@0.1.8
 * Get-Extension: Fixing CouldRun/Run issue with multiple ParameterSets (#31)
 * Install-Piecemeal: Improving Install Message (#32)
 
 ---
 
-## 0.1.7
+## Piecemeal@0.1.7
 * Get-Extension: Now inherits ParameterSetName (#28)
 * Get-Extension: Fixing issue properly displaying Valid Set (#29)
 
 ---
 
-## 0.1.6
+## Piecemeal@0.1.6
 * Get-Extension now supports all validation attributes (#26/#25)
 
 ---
 
-## 0.1.5
+## Piecemeal@0.1.5
 * Extensions are now Sortable (#19)
 * Get-Extension supports -ExtensionName (#20)
 * Get-Extension/Install-Piecemeal renaming parameter -ExtensionNameRegex to -ExtensionPattern (#21)
@@ -193,13 +208,13 @@
 
 ---
 
-## 0.1.4
+## Piecemeal@0.1.4
 * Get-Extension:
   * Can now filter extension parameters based off of command (#17)
 
 ---
 
-## 0.1.3
+## Piecemeal@0.1.3
 * Get-Extension:
   * Added -RequireExtensionAttribute (#13)
   * Added -RequireCmdletAttribute (#14)
@@ -212,14 +227,14 @@
 
 ---
 
-## 0.1.2
+## Piecemeal@0.1.2
 * Get-Extension:
   * Added -NoMandatoryDynamicParameter (#6 / #4)
   * [Parameter] attributes are now copied, so underlying commands are unchanged (#7)
 
 ---
 
-## 0.1.1
+## Piecemeal@0.1.1
 * Get-Extension:
   * -Parameter not accepts ValueFromPipelineByPropertyName (#2)
   * -CommandName now works (#3)
@@ -227,7 +242,7 @@
 
 ---
 
-## 0.1
+## Piecemeal@0.1
 * Initial Release of Piecemeal
 
 ---

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -666,7 +666,7 @@
                 return $true
             }), $true)
             #endregion .IsParameterValid
-
+            
             #region .CouldPipe
             $extCmd.PSObject.Methods.Add([PSScriptMethod]::new('CouldPipe', {
                 param([PSObject]$InputObject)
@@ -716,6 +716,31 @@
                 }
             }), $true)
             #endregion .CouldPipe
+
+            #region .CouldPipeType
+            $extCmd.PSObject.Methods.Add([PSScriptMethod]::new('CouldPipeType', {
+                param([Type]$Type)
+                
+                foreach ($paramSet in $this.ParameterSets) {
+                    if ($ParameterSetName -and $paramSet.Name -ne $ParameterSetName) { continue }
+                    # Walk thru each parameter of this command
+                    foreach ($myParam in $paramSet.Parameters) {
+                        # If the parameter is ValueFromPipeline
+                        if ($myParam.ValueFromPipeline -and (
+                                $myParam.ParameterType -eq $Type -or
+                                # (or a subclass of that type)
+                                $Type.IsSubClassOf($myParam.ParameterType) -or
+                                # (or an inteface of that type)
+                                ($myParam.ParameterType.IsInterface -and $Type.GetInterface($myParam.ParameterType))
+                            )
+                        ) {
+                            return $true
+                        }                        
+                    }
+                    return $false
+                }
+            }), $true)
+            #endregion .CouldPipeType
 
             #region .CouldRun
             $extCmd.PSObject.Methods.Add([PSScriptMethod]::new('CouldRun', {

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -805,6 +805,7 @@
             #endregion .CouldRun
 
             
+            # Decorate our return (so that it can be uniquely extended)
             if (-not $ExtensionTypeName) {
                 $ExtensionTypeName = 'Extension'
             }

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -804,11 +804,12 @@
             }), $true)
             #endregion .CouldRun
 
-            $extCmd.pstypenames.clear()
-            if ($ExtensionTypeName) {
-                $extCmd.pstypenames.add($ExtensionTypeName)
-            } else {
-                $extCmd.pstypenames.add('Extension')
+            
+            if (-not $ExtensionTypeName) {
+                $ExtensionTypeName = 'Extension'
+            }
+            if ($extCmd.pstypenames -notcontains $ExtensionTypeName) {            
+                $extCmd.pstypenames.insert(0,$ExtensionTypeName)
             }
 
             $extCmd

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -571,7 +571,7 @@
                 $ExtensionDynamicParameters = [Management.Automation.RuntimeDefinedParameterDictionary]::new()
                 $Extension = $this
 
-                :nextDynamicParameter foreach ($in in @(([Management.Automation.CommandMetaData]$Extension).Parameters.Keys)) {
+                :nextDynamicParameter foreach ($in in @(($Extension -as [Management.Automation.CommandMetaData]).Parameters.Keys)) {
                     $attrList = [Collections.Generic.List[Attribute]]::new()
                     $validCommandNames = @()
                     foreach ($attr in $extension.Parameters[$in].attributes) {
@@ -846,7 +846,7 @@
                     # Then, walk over each extension parameter.
                     foreach ($kv in $extensionParams.GetEnumerator()) {
                         # If the $CommandExtended had a built-in parameter, we cannot override it, so skip it.
-                        if ($commandExtended -and ([Management.Automation.CommandMetaData]$commandExtended).Parameters.$($kv.Key)) {
+                        if ($commandExtended -and ($commandExtended -as [Management.Automation.CommandMetaData]).Parameters.$($kv.Key)) {
                             continue
                         }
 
@@ -1022,7 +1022,7 @@
                     elseif ($loadedModule.PrivateData.PSData.Tags -contains $myModuleName -or $loadedModule.Name -eq $myModuleName) {
                         $loadedModule |
                             Split-Path |
-                            Get-ChildItem -Recurse |
+                            Get-ChildItem -Recurse -File |
                             Where-Object { $_.Name -Match $extensionFullRegex } |
                             ConvertToExtension                        
                     }
@@ -1047,7 +1047,7 @@
     process {
 
         if ($ExtensionPath) {
-            Get-ChildItem -Recurse -Path $ExtensionPath |
+            Get-ChildItem -Recurse -Path $ExtensionPath -File |
                 Where-Object { $_.Name -Match $extensionFullRegex } |
                 ConvertToExtension |
                 . WhereExtends $CommandName |

--- a/Get-Extension.ps1
+++ b/Get-Extension.ps1
@@ -363,7 +363,7 @@
             ), $true)
 
             $extCmd.PSObject.Properties.Add([PSNoteProperty]::new(
-                '.DisplayName', "`$this.Name -replace '$extensionFullRegex'"
+                '.DisplayName', "$($extCmd.Name -replace $extensionFullRegex)"
             ), $true)            
             #endregion .DisplayName
             

--- a/Piecemeal.psd1
+++ b/Piecemeal.psd1
@@ -1,5 +1,5 @@
 ﻿@{
-    ModuleVersion    = '0.3.8'
+    ModuleVersion    = '0.3.9'
     RootModule       = 'Piecemeal.psm1'
     Description      = 'Easy Extensible Plugins for PowerShell'
     GUID             = '91e2c328-d7dc-44a3-aeeb-ef3b19c36767'
@@ -13,20 +13,35 @@
               ProjectURI   = 'https://github.com/StartAutomating/Piecemeal'
               LicenseURI   = 'https://github.com/StartAutomating/Piecemeal/blob/main/LICENSE'
               ReleaseNotes = @'
-## 0.3.8:
+## Piecemeal@0.3.9:
+
+* Allowing any command to be an extension! (Fixes #120)
+
+Functions, Cmdlets, and Aliases that meet the the naming convention will be seen as extensions by Get-Extension.
+
+In most cases, this allows extensions to be defined in memory or on disk.
+
+* Allowing .DisplayName to be set (Fixes #123)
+* Adding .CouldPipeType to all extensions (Fixes #121)
+* Not allowing a directories to be extensions (for now) (Fixes #125)
+* Not clearing an extension's .PSTypeNames (inserting instead) (Fixes #126)
+
+---
+
+## Piecemeal@0.3.8:
 
 * Adding .HasValidation to all extensions (Fixes #117)
 * All extension methods and properties are now prevalidated in case of collision (Fixes #118)
 
 ---
 
-## 0.3.7:
+## Piecemeal@0.3.7:
 
 * Get-Extension:  Stringifying input for ValidatePattern (Fixes #114)
 
 ---
 
-## 0.3.6:
+## Piecemeal@0.3.6:
 
 * Get-Extension -CouldPipe can now handle PSTypeName attributes (Fixes #109)
 * Piecemeal action no longer produces output variables (Fixes #110)
@@ -34,12 +49,12 @@
 
 ---
 
-## 0.3.5:
+## Piecemeal@0.3.5:
 * GitHub Action now checks if it is on a branch (Fixes #107)
 
 ---
 
-## 0.3.4:
+## Piecemeal@0.3.4:
 * Get-Extension
   * Adding -Force (Fixes #103)
   * Caching allCommands (Fixes #104)
@@ -47,13 +62,13 @@
 
 ---
 
-## 0.3.3:
+## Piecemeal@0.3.3:
 * Consolidating -Help parameters (#101)
 * Fixing .GetHelpField (#100)
 
 ---
 
-## 0.3.2:
+## Piecemeal@0.3.2:
 * Piecemeal Available as a GitHub Action (#56)
 * Get-Extension:
   * Adding .BlockComments property (#96)
@@ -65,43 +80,43 @@
 
 ---
 
-## 0.3.1:
+## Piecemeal@0.3.1:
 * Get-Extension:
-   * New Properties/Methods for Each Extension
-     * .Category (#89)
-     * .GetHelpField() (#91)
-     * .Examples (#87)
-     * .Links    (#88)
-     * .Metadata (#90)
-   * Removing -RequireExtensionAttribute (#92)
+    * New Properties/Methods for Each Extension
+      * .Category (#89)
+      * .GetHelpField() (#91)
+      * .Examples (#87)
+      * .Links    (#88)
+      * .Metadata (#90)
+    * Removing -RequireExtensionAttribute (#92)
 
 ---
 
-## 0.3.0:
+## Piecemeal@0.3.0:
 * Get-Extension:
   * Ensuring Regexes IgnoreCase (#85)
   * Trimming Trailing Whitepace from .Synopsis and .Description (#84)
 
 ---  
 
-## 0.2.9.1:
+## Piecemeal@0.2.9.1:
 * Fixing Get-Extension overcollection (#82)
 
 ---
 
-## 0.2.9:
+## Piecemeal@0.2.9:
 * Get-Extension:
-   * -CouldRun now honors validation attributes (#77)
-   * -CouldPipe now honors validation attributes (#78)
-   * -ExtensionName now supports Regex Literal Aliases ```[Alias(/Expression/)]``` (#80)
-   * -CouldRun, -CouldPipe, -Validate are no longer mutually exclusive (#79)
+    * -CouldRun now honors validation attributes (#77)
+    * -CouldPipe now honors validation attributes (#78)
+    * -ExtensionName now supports Regex Literal Aliases ```[Alias(/Expression/)]``` (#80)
+    * -CouldRun, -CouldPipe, -Validate are no longer mutually exclusive (#79)
 * Install-Piecemeal
-   * Support for custom -WhereObject (#73)            
-   * Support for custom -ForeachObject (#74)
+    * Support for custom -WhereObject (#73)            
+    * Support for custom -ForeachObject (#74)
 
 ---
 
-## 0.2.8
+## Piecemeal@0.2.8
 * Get-Extension:  
   * Performance Improvements (#75)
   * Regular Expressions now IgnorePatternWhitespace (#71)
@@ -113,14 +128,14 @@
 
 ---
 
-## 0.2.7
+## Piecemeal@0.2.7
 * Get-Extension
   * Allowing any command type (#65)
   * Fixing -CouldPipe (#67)
 
 ---
 
-## 0.2.6
+## Piecemeal@0.2.6
 * Get-Extension:
   * Matching -ExtensionName support aliases (#63)
   * Matching -ExtensionName against .DisplayName or .Name (#61)
@@ -128,25 +143,25 @@
 
 ---
 
-## 0.2.5
+## Piecemeal@0.2.5
 * Get-Extension:  Adding -CouldPipe (#58)
 * Get-Extension:  Fixing .Tags based inclusion (#57)
 
 ---
 
-## 0.2.4
+## Piecemeal@0.2.4
 * Install-Piecemeal:  Making -ExtensionModule Optional (#54)
 
 ---
 
-## 0.2.3
+## Piecemeal@0.2.3
 * Adding New-Extension (#51)
 * Generating Docs (#52)
 * Allowing New-Extension to be installed with Install-Piecemeal
 
 ---
 
-## 0.2.2
+## Piecemeal@0.2.2
 * Adding test for [ValidateScript] (#47)
 * Updating Piecemeal tests (checking validation order) (#48)
 * Get-Extension:  Fixing -ValidateInput logic (#48)
@@ -154,7 +169,7 @@
 
 ---
 
-## 0.2.1
+## Piecemeal@0.2.1
 * Get-Extension:  Support for -AllValid (#45)
 * Get-Extension:  Removing Validation Errors when -ErrorAction is ignore (#43)
 * Updating Piecemeal tests: Adding test for Steppable Pipeline (#42)
@@ -163,7 +178,7 @@
 
 ---
 
-## 0.2
+## Piecemeal@0.2
 * Adding formatting for extensions (#40)
 * Updating Piecemeal tests (account for Regex) (#39)
 * Get-Extension:  Regex support for [Cmdlet] attribute (#39)
@@ -172,35 +187,35 @@
 
 ---
 
-## 0.1.10
+## Piecemeal@0.1.10
 * Get-Extension:  Adding -ParameterSetName (#36)
 * Install-Extension:  Adding -Force to Import-Module in Install Note (#32)
 
 ---
 
-## 0.1.9
+## Piecemeal@0.1.9
 * Get-Extension: Fixing CouldRun/Run issue with multiple ParameterSets (with other attributes present) (#31)
 
 ---
 
-## 0.1.8
+## Piecemeal@0.1.8
 * Get-Extension: Fixing CouldRun/Run issue with multiple ParameterSets (#31)
 * Install-Piecemeal: Improving Install Message (#32)
 
 ---
 
-## 0.1.7
+## Piecemeal@0.1.7
 * Get-Extension: Now inherits ParameterSetName (#28)
 * Get-Extension: Fixing issue properly displaying Valid Set (#29)
 
 ---
 
-## 0.1.6
+## Piecemeal@0.1.6
 * Get-Extension now supports all validation attributes (#26/#25)
 
 ---
 
-## 0.1.5
+## Piecemeal@0.1.5
 * Extensions are now Sortable (#19)
 * Get-Extension supports -ExtensionName (#20)
 * Get-Extension/Install-Piecemeal renaming parameter -ExtensionNameRegex to -ExtensionPattern (#21)
@@ -208,13 +223,13 @@
 
 ---
 
-## 0.1.4
+## Piecemeal@0.1.4
 * Get-Extension:
   * Can now filter extension parameters based off of command (#17)
 
 ---
 
-## 0.1.3
+## Piecemeal@0.1.3
 * Get-Extension:
   * Added -RequireExtensionAttribute (#13)
   * Added -RequireCmdletAttribute (#14)
@@ -227,14 +242,14 @@
 
 ---
 
-## 0.1.2
+## Piecemeal@0.1.2
 * Get-Extension:
   * Added -NoMandatoryDynamicParameter (#6 / #4)
   * [Parameter] attributes are now copied, so underlying commands are unchanged (#7)
 
 ---
 
-## 0.1.1
+## Piecemeal@0.1.1
 * Get-Extension:
   * -Parameter not accepts ValueFromPipelineByPropertyName (#2)
   * -CommandName now works (#3)
@@ -242,7 +257,7 @@
 
 ---
 
-## 0.1
+## Piecemeal@0.1
 * Initial Release of Piecemeal
 
 ---

--- a/Piecemeal.tests.ps1
+++ b/Piecemeal.tests.ps1
@@ -147,6 +147,7 @@ describe Piecemeal {
             }
         } | Set-Content .\09.ext.ps1
 
+        New-Module -Name PiecemealDynamicTest -ScriptBlock {
         function func.ext.ps1 {
             [ValidateScript({                
                 return $true
@@ -166,6 +167,8 @@ describe Piecemeal {
         }
 
         Set-Alias alias.ext.ps1 thisWillBeAliasedAndBecomeAnExtension
+        Export-ModuleMember -Function * -Alias *
+        } | Import-Module -Global -Force
     }
     context 'Get-Extension' {
         it '-ExtensionPath' {
@@ -317,6 +320,7 @@ describe Piecemeal {
 
     afterAll {
         Get-ChildItem -Path $pwd -Filter *.ext.ps1 | Remove-Item
+        Remove-Module -Name PiecemealDynamicTest
     }
 }
 Pop-Location

--- a/Piecemeal.tests.ps1
+++ b/Piecemeal.tests.ps1
@@ -146,6 +146,26 @@ describe Piecemeal {
                 $MyCustomTypeName
             }
         } | Set-Content .\09.ext.ps1
+
+        function func.ext.ps1 {
+            [ValidateScript({                
+                return $true
+            })]
+            param()
+
+            $MyInvocation.MyCommand.Name
+        }
+
+        function thisWillBeAliasedAndBecomeAnExtension {
+            [ValidateScript({                
+                return $true
+            })]
+            param()
+
+            $MyInvocation.MyCommand.Name
+        }
+
+        Set-Alias alias.ext.ps1 thisWillBeAliasedAndBecomeAnExtension
     }
     context 'Get-Extension' {
         it '-ExtensionPath' {
@@ -242,6 +262,22 @@ describe Piecemeal {
             $sp.Process([PSCustomObject]@{Bar='bar'}) | Should -Be @('Foo','Bar')
             $sp.End() | Should -be 'Foo'
         }
+
+        context "Functions as extensions" {
+            it 'Can see a function as an extension' {
+                
+        
+                Get-Extension -ExtensionName func* -Like -Force | 
+                    Should -Not -Be $null
+            }
+    
+            it 'Can see an alias an an extension' {
+                
+        
+                Get-Extension -ExtensionName alias* -Like -Force | 
+                    Should -Not -Be $null
+            }    
+        }        
     }
 
     context 'New-Extension' {

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 ## What is Piecemeal?
 
-Piecemeal is a little PowerShell module that helps solve a big problem:  allowing functions to be extended.
+Piecemeal is a little PowerShell module that helps solve a big problem: PowerShell extensibility.
 
-Piecemeal standardizes the creation of PowerShell extension scripts, and provides an embeddable engine for extensibility.
+Piecemeal allows function and scripts to have extended capabilities and act as extensions for any command.
+
+Piecemeal standardizes these capabilities and provides a simple function you can embed into any module to power an engine of extensibility.
 
 #### Installing Piecemeal
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,17 +1,32 @@
-## 0.3.8:
+## Piecemeal@0.3.9:
+
+* Allowing any command to be an extension! (Fixes #120)
+
+Functions, Cmdlets, and Aliases that meet the the naming convention will be seen as extensions by Get-Extension.
+
+In most cases, this allows extensions to be defined in memory or on disk.
+
+* Allowing .DisplayName to be set (Fixes #123)
+* Adding .CouldPipeType to all extensions (Fixes #121)
+* Not allowing a directories to be extensions (for now) (Fixes #125)
+* Not clearing an extension's .PSTypeNames (inserting instead) (Fixes #126)
+
+---
+
+## Piecemeal@0.3.8:
 
 * Adding .HasValidation to all extensions (Fixes #117)
 * All extension methods and properties are now prevalidated in case of collision (Fixes #118)
 
 ---
 
-## 0.3.7:
+## Piecemeal@0.3.7:
 
 * Get-Extension:  Stringifying input for ValidatePattern (Fixes #114)
 
 ---
 
-## 0.3.6:
+## Piecemeal@0.3.6:
 
 * Get-Extension -CouldPipe can now handle PSTypeName attributes (Fixes #109)
 * Piecemeal action no longer produces output variables (Fixes #110)
@@ -19,12 +34,12 @@
 
 ---
 
-## 0.3.5:
+## Piecemeal@0.3.5:
 * GitHub Action now checks if it is on a branch (Fixes #107)
 
 ---
 
-## 0.3.4:
+## Piecemeal@0.3.4:
 * Get-Extension
   * Adding -Force (Fixes #103)
   * Caching allCommands (Fixes #104)
@@ -32,13 +47,13 @@
 
 ---
 
-## 0.3.3:
+## Piecemeal@0.3.3:
 * Consolidating -Help parameters (#101)
 * Fixing .GetHelpField (#100)
 
 ---
 
-## 0.3.2:
+## Piecemeal@0.3.2:
 * Piecemeal Available as a GitHub Action (#56)
 * Get-Extension:
   * Adding .BlockComments property (#96)
@@ -50,7 +65,7 @@
 
 ---
 
-## 0.3.1:
+## Piecemeal@0.3.1:
 * Get-Extension:
    * New Properties/Methods for Each Extension
      * .Category (#89)
@@ -62,19 +77,19 @@
 
 ---
 
-## 0.3.0:
+## Piecemeal@0.3.0:
 * Get-Extension:
   * Ensuring Regexes IgnoreCase (#85)
   * Trimming Trailing Whitepace from .Synopsis and .Description (#84)
 
 ---  
 
-## 0.2.9.1:
+## Piecemeal@0.2.9.1:
 * Fixing Get-Extension overcollection (#82)
 
 ---
 
-## 0.2.9:
+## Piecemeal@0.2.9:
 * Get-Extension:
    * -CouldRun now honors validation attributes (#77)
    * -CouldPipe now honors validation attributes (#78)
@@ -86,7 +101,7 @@
 
 ---
 
-## 0.2.8
+## Piecemeal@0.2.8
 * Get-Extension:  
   * Performance Improvements (#75)
   * Regular Expressions now IgnorePatternWhitespace (#71)
@@ -98,14 +113,14 @@
 
 ---
 
-## 0.2.7
+## Piecemeal@0.2.7
 * Get-Extension
   * Allowing any command type (#65)
   * Fixing -CouldPipe (#67)
 
 ---
 
-## 0.2.6
+## Piecemeal@0.2.6
 * Get-Extension:
   * Matching -ExtensionName support aliases (#63)
   * Matching -ExtensionName against .DisplayName or .Name (#61)
@@ -113,25 +128,25 @@
 
 ---
 
-## 0.2.5
+## Piecemeal@0.2.5
 * Get-Extension:  Adding -CouldPipe (#58)
 * Get-Extension:  Fixing .Tags based inclusion (#57)
 
 ---
 
-## 0.2.4
+## Piecemeal@0.2.4
 * Install-Piecemeal:  Making -ExtensionModule Optional (#54)
 
 ---
 
-## 0.2.3
+## Piecemeal@0.2.3
 * Adding New-Extension (#51)
 * Generating Docs (#52)
 * Allowing New-Extension to be installed with Install-Piecemeal
 
 ---
 
-## 0.2.2
+## Piecemeal@0.2.2
 * Adding test for [ValidateScript] (#47)
 * Updating Piecemeal tests (checking validation order) (#48)
 * Get-Extension:  Fixing -ValidateInput logic (#48)
@@ -139,7 +154,7 @@
 
 ---
 
-## 0.2.1
+## Piecemeal@0.2.1
 * Get-Extension:  Support for -AllValid (#45)
 * Get-Extension:  Removing Validation Errors when -ErrorAction is ignore (#43)
 * Updating Piecemeal tests: Adding test for Steppable Pipeline (#42)
@@ -148,7 +163,7 @@
 
 ---
 
-## 0.2
+## Piecemeal@0.2
 * Adding formatting for extensions (#40)
 * Updating Piecemeal tests (account for Regex) (#39)
 * Get-Extension:  Regex support for [Cmdlet] attribute (#39)
@@ -157,35 +172,35 @@
 
 ---
 
-## 0.1.10
+## Piecemeal@0.1.10
 * Get-Extension:  Adding -ParameterSetName (#36)
 * Install-Extension:  Adding -Force to Import-Module in Install Note (#32)
 
 ---
 
-## 0.1.9
+## Piecemeal@0.1.9
 * Get-Extension: Fixing CouldRun/Run issue with multiple ParameterSets (with other attributes present) (#31)
 
 ---
 
-## 0.1.8
+## Piecemeal@0.1.8
 * Get-Extension: Fixing CouldRun/Run issue with multiple ParameterSets (#31)
 * Install-Piecemeal: Improving Install Message (#32)
 
 ---
 
-## 0.1.7
+## Piecemeal@0.1.7
 * Get-Extension: Now inherits ParameterSetName (#28)
 * Get-Extension: Fixing issue properly displaying Valid Set (#29)
 
 ---
 
-## 0.1.6
+## Piecemeal@0.1.6
 * Get-Extension now supports all validation attributes (#26/#25)
 
 ---
 
-## 0.1.5
+## Piecemeal@0.1.5
 * Extensions are now Sortable (#19)
 * Get-Extension supports -ExtensionName (#20)
 * Get-Extension/Install-Piecemeal renaming parameter -ExtensionNameRegex to -ExtensionPattern (#21)
@@ -193,13 +208,13 @@
 
 ---
 
-## 0.1.4
+## Piecemeal@0.1.4
 * Get-Extension:
   * Can now filter extension parameters based off of command (#17)
 
 ---
 
-## 0.1.3
+## Piecemeal@0.1.3
 * Get-Extension:
   * Added -RequireExtensionAttribute (#13)
   * Added -RequireCmdletAttribute (#14)
@@ -212,14 +227,14 @@
 
 ---
 
-## 0.1.2
+## Piecemeal@0.1.2
 * Get-Extension:
   * Added -NoMandatoryDynamicParameter (#6 / #4)
   * [Parameter] attributes are now copied, so underlying commands are unchanged (#7)
 
 ---
 
-## 0.1.1
+## Piecemeal@0.1.1
 * Get-Extension:
   * -Parameter not accepts ValueFromPipelineByPropertyName (#2)
   * -CommandName now works (#3)
@@ -227,7 +242,7 @@
 
 ---
 
-## 0.1
+## Piecemeal@0.1
 * Initial Release of Piecemeal
 
 ---

--- a/docs/Get-Extension.md
+++ b/docs/Get-Extension.md
@@ -1,9 +1,17 @@
 Get-Extension
 -------------
+
+
+
+
 ### Synopsis
 Gets Extensions
 
+
+
 ---
+
+
 ### Description
 
 Gets Extensions.
@@ -12,15 +20,24 @@ Extensions can be found in:
 
 * Any module that includes -ExtensionModuleName in it's tags.
 * The directory specified in -ExtensionPath
+* Commands that meet the naming criteria
+
+
 
 ---
+
+
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
 Get-Extension
 ```
 
+
+
 ---
+
+
 ### Parameters
 #### **ExtensionPath**
 
@@ -31,13 +48,12 @@ If provided, will look beneath a specific path for extensions.
 
 
 
-|Type      |Required|Position|PipelineInput        |
-|----------|--------|--------|---------------------|
-|`[String]`|false   |1       |true (ByPropertyName)|
+|Type      |Required|Position|PipelineInput        |Aliases |
+|----------|--------|--------|---------------------|--------|
+|`[String]`|false   |1       |true (ByPropertyName)|Fullname|
 
 
 
----
 #### **Force**
 
 If set, will clear caches of extensions, forcing a refresh.
@@ -53,7 +69,6 @@ If set, will clear caches of extensions, forcing a refresh.
 
 
 
----
 #### **CommandName**
 
 If provided, will get extensions that extend a given command
@@ -63,13 +78,12 @@ If provided, will get extensions that extend a given command
 
 
 
-|Type        |Required|Position|PipelineInput        |
-|------------|--------|--------|---------------------|
-|`[String[]]`|false   |2       |true (ByPropertyName)|
+|Type        |Required|Position|PipelineInput        |Aliases            |
+|------------|--------|--------|---------------------|-------------------|
+|`[String[]]`|false   |2       |true (ByPropertyName)|ThatExtends<br/>For|
 
 
 
----
 #### **ExtensionPattern**
 
 The regular expression used to determine if a script is an extension.
@@ -80,13 +94,12 @@ By default, '(extension|ext|ex|x)\.ps1$'
 
 
 
-|Type        |Required|Position|PipelineInput        |
-|------------|--------|--------|---------------------|
-|`[String[]]`|false   |3       |true (ByPropertyName)|
+|Type        |Required|Position|PipelineInput        |Aliases                                 |
+|------------|--------|--------|---------------------|----------------------------------------|
+|`[String[]]`|false   |3       |true (ByPropertyName)|ExtensionNameRegEx<br/>ExtensionPatterns|
 
 
 
----
 #### **ExtensionName**
 
 The name of an extension.
@@ -105,7 +118,6 @@ If the extension has an Alias with a regular expression literal (```'/Expression
 
 
 
----
 #### **Like**
 
 If provided, will treat -ExtensionName as a wildcard.
@@ -124,7 +136,6 @@ If the extension has an Alias with a regular expression literal (```'/Expression
 
 
 
----
 #### **Match**
 
 If provided, will treat -ExtensionName as a regular expression.
@@ -143,7 +154,6 @@ If the extension has an Alias with a regular expression literal (```'/Expression
 
 
 
----
 #### **ExtensionModule**
 
 The extension module.  If provided, this will have to prefix the ExtensionNameRegex
@@ -159,7 +169,6 @@ The extension module.  If provided, this will have to prefix the ExtensionNameRe
 
 
 
----
 #### **ExtensionModuleAlias**
 
 A list of extension module aliases.
@@ -175,7 +184,6 @@ A list of extension module aliases.
 
 
 
----
 #### **ExtensionTypeName**
 
 The extension type name.
@@ -191,7 +199,6 @@ The extension type name.
 
 
 
----
 #### **DynamicParameter**
 
 If set, will return the dynamic parameters object of all the extensions for a given command.
@@ -207,7 +214,6 @@ If set, will return the dynamic parameters object of all the extensions for a gi
 
 
 
----
 #### **CouldRun**
 
 If set, will return if the extension could run.
@@ -217,13 +223,12 @@ If set, will return if the extension could run.
 
 
 
-|Type      |Required|Position|PipelineInput        |
-|----------|--------|--------|---------------------|
-|`[Switch]`|false   |named   |true (ByPropertyName)|
+|Type      |Required|Position|PipelineInput        |Aliases|
+|----------|--------|--------|---------------------|-------|
+|`[Switch]`|false   |named   |true (ByPropertyName)|CanRun |
 
 
 
----
 #### **CouldPipe**
 
 If set, will return if the extension could accept this input from the pipeline.
@@ -233,13 +238,12 @@ If set, will return if the extension could accept this input from the pipeline.
 
 
 
-|Type        |Required|Position|PipelineInput|
-|------------|--------|--------|-------------|
-|`[PSObject]`|false   |8       |false        |
+|Type        |Required|Position|PipelineInput|Aliases|
+|------------|--------|--------|-------------|-------|
+|`[PSObject]`|false   |8       |false        |CanPipe|
 
 
 
----
 #### **Run**
 
 If set, will run the extension.  If -Stream is passed, results will be directly returned.
@@ -256,7 +260,6 @@ By default, extension results are wrapped in a return object.
 
 
 
----
 #### **Stream**
 
 If set, will stream output from running the extension.
@@ -273,7 +276,6 @@ By default, extension results are wrapped in a return object.
 
 
 
----
 #### **DynamicParameterSetName**
 
 If set, will return the dynamic parameters of all extensions for a given command, using the provided DynamicParameterSetName.
@@ -290,7 +292,6 @@ Implies -DynamicParameter.
 
 
 
----
 #### **DynamicParameterPositionOffset**
 
 If provided, will return the dynamic parameters of all extensions for a given command, with all positional parameters offset.
@@ -307,7 +308,6 @@ Implies -DynamicParameter.
 
 
 
----
 #### **NoMandatoryDynamicParameter**
 
 If set, will return the dynamic parameters of all extensions for a given command, with all mandatory parameters marked as optional.
@@ -318,13 +318,12 @@ Implies -DynamicParameter.  Does not actually prevent the parameter from being M
 
 
 
-|Type      |Required|Position|PipelineInput        |
-|----------|--------|--------|---------------------|
-|`[Switch]`|false   |named   |true (ByPropertyName)|
+|Type      |Required|Position|PipelineInput        |Aliases                     |
+|----------|--------|--------|---------------------|----------------------------|
+|`[Switch]`|false   |named   |true (ByPropertyName)|NoMandatoryDynamicParameters|
 
 
 
----
 #### **RequireExtensionAttribute**
 
 If set, will require a [Runtime.CompilerServices.Extension()] attribute to be considered an extension.
@@ -340,7 +339,6 @@ If set, will require a [Runtime.CompilerServices.Extension()] attribute to be co
 
 
 
----
 #### **RequireCmdletAttribute**
 
 If set, will require a [Management.Automation.Cmdlet] attribute to be considered an extension.
@@ -357,7 +355,6 @@ This attribute can associate the extension with one or more commands.
 
 
 
----
 #### **ValidateInput**
 
 If set, will validate this input against [ValidateScript], [ValidatePattern], [ValidateSet], and [ValidateRange] attributes found on an extension.
@@ -373,7 +370,6 @@ If set, will validate this input against [ValidateScript], [ValidatePattern], [V
 
 
 
----
 #### **AllValid**
 
 If set, will validate this input against all [ValidateScript], [ValidatePattern], [ValidateSet], and [ValidateRange] attributes found on an extension.
@@ -390,7 +386,6 @@ By default, if any validation attribute returned true, the extension is consider
 
 
 
----
 #### **ParameterSetName**
 
 The name of the parameter set.  This is used by -CouldRun and -Run to enforce a single specific parameter set.
@@ -406,7 +401,6 @@ The name of the parameter set.  This is used by -CouldRun and -Run to enforce a 
 
 
 
----
 #### **Parameter**
 
 The parameters to the extension.  Only used when determining if the extension -CouldRun.
@@ -416,13 +410,12 @@ The parameters to the extension.  Only used when determining if the extension -C
 
 
 
-|Type           |Required|Position|PipelineInput        |
-|---------------|--------|--------|---------------------|
-|`[IDictionary]`|false   |13      |true (ByPropertyName)|
+|Type           |Required|Position|PipelineInput        |Aliases                                                  |
+|---------------|--------|--------|---------------------|---------------------------------------------------------|
+|`[IDictionary]`|false   |13      |true (ByPropertyName)|Parameters<br/>ExtensionParameter<br/>ExtensionParameters|
 
 
 
----
 #### **SteppablePipeline**
 
 If set, will output a steppable pipeline for the extension.
@@ -440,7 +433,6 @@ This allows for the execution of more than one extension at a time.
 
 
 
----
 #### **Help**
 
 If set, will output the help for the extensions
@@ -456,16 +448,23 @@ If set, will output the help for the extensions
 
 
 
+
+
 ---
+
+
 ### Outputs
 * Extension
 
 
 
 
+
+
 ---
+
+
 ### Syntax
 ```PowerShell
 Get-Extension [[-ExtensionPath] <String>] [-Force] [[-CommandName] <String[]>] [[-ExtensionPattern] <String[]>] [[-ExtensionName] <String[]>] [-Like] [-Match] [[-ExtensionModule] <String>] [[-ExtensionModuleAlias] <String[]>] [[-ExtensionTypeName] <String>] [-DynamicParameter] [-CouldRun] [[-CouldPipe] <PSObject>] [-Run] [-Stream] [[-DynamicParameterSetName] <String>] [[-DynamicParameterPositionOffset] <Int32>] [-NoMandatoryDynamicParameter] [-RequireExtensionAttribute] [-RequireCmdletAttribute] [[-ValidateInput] <PSObject>] [-AllValid] [[-ParameterSetName] <String>] [[-Parameter] <IDictionary>] [-SteppablePipeline] [-Help] [<CommonParameters>]
 ```
----

--- a/docs/Install-Piecemeal.md
+++ b/docs/Install-Piecemeal.md
@@ -1,22 +1,38 @@
 Install-Piecemeal
 -----------------
+
+
+
+
 ### Synopsis
 Installs Piecemeal
 
+
+
 ---
+
+
 ### Description
 
 Installs Piecemeal into a module.
 
 This enables extensibility within the module.
 
+
+
 ---
+
+
 ### Related Links
 * [Get-Extension](Get-Extension.md)
 
 
 
+
+
 ---
+
+
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
@@ -28,7 +44,11 @@ Install-Piecemeal -ExtensionModule RoughDraft -ExtensionModuleAlias rd -Extensio
 1{0,1})$','\.ps(?<IsPowerShell>1{0,1})\.(?<Extension>[^.]+$)','\.ps(?<IsPowerShell>1{0,1})$' -OutputPath '.\Get-PipeScript.ps1' -RenameVariable @{ExtensionPath='PipeScriptPath'}
 ```
 
+
+
 ---
+
+
 ### Parameters
 #### **ExtensionModule**
 
@@ -45,7 +65,6 @@ The name of the module that is being extended.
 
 
 
----
 #### **Verb**
 
 The verbs to install.  By default, installs Get.
@@ -68,7 +87,6 @@ Valid Values:
 
 
 
----
 #### **ExtensionModuleAlias**
 
 One or more aliases used to refer to the module being extended.
@@ -84,7 +102,6 @@ One or more aliases used to refer to the module being extended.
 
 
 
----
 #### **ExtensionPattern**
 
 If provided, will override the default extension name regular expression
@@ -95,13 +112,12 @@ If provided, will override the default extension name regular expression
 
 
 
-|Type        |Required|Position|PipelineInput        |
-|------------|--------|--------|---------------------|
-|`[String[]]`|false   |4       |true (ByPropertyName)|
+|Type        |Required|Position|PipelineInput        |Aliases                                 |
+|------------|--------|--------|---------------------|----------------------------------------|
+|`[String[]]`|false   |4       |true (ByPropertyName)|ExtensionNameRegEx<br/>ExtensionPatterns|
 
 
 
----
 #### **ExtensionTypeName**
 
 The type name to add to an extension.  This can be used to format the extension.
@@ -117,7 +133,6 @@ The type name to add to an extension.  This can be used to format the extension.
 
 
 
----
 #### **ExtensionNoun**
 
 The noun used for any extension commands.
@@ -133,7 +148,6 @@ The noun used for any extension commands.
 
 
 
----
 #### **RequireCmdletAttribute**
 
 If set, will require a [Management.Automation.Cmdlet] attribute to be considered an extension.
@@ -150,7 +164,6 @@ This attribute can associate the extension with one or more commands.
 
 
 
----
 #### **OutputPath**
 
 The output path.
@@ -168,7 +181,6 @@ Otherwise, contents will be returned.
 
 
 
----
 #### **RenameVariable**
 
 If provided, will rename variables.
@@ -184,7 +196,6 @@ If provided, will rename variables.
 
 
 
----
 #### **ForeachObject**
 
 A custom Foreach-Object that will be appended to main pipelines within Get-Extension.
@@ -200,7 +211,6 @@ A custom Foreach-Object that will be appended to main pipelines within Get-Exten
 
 
 
----
 #### **WhereObject**
 
 A custom Where-Object that will be injected to the main pipelines within Get-Extension
@@ -216,7 +226,11 @@ A custom Where-Object that will be injected to the main pipelines within Get-Ext
 
 
 
+
+
 ---
+
+
 ### Outputs
 * [String](https://learn.microsoft.com/en-us/dotnet/api/System.String)
 
@@ -226,11 +240,20 @@ A custom Where-Object that will be injected to the main pipelines within Get-Ext
 
 
 
+
+
 ---
+
+
+### Notes
+This returns a modified Get-Extension
+
+
+
+---
+
+
 ### Syntax
 ```PowerShell
 Install-Piecemeal [[-ExtensionModule] <String>] [[-Verb] <String[]>] [[-ExtensionModuleAlias] <String[]>] [[-ExtensionPattern] <String[]>] [[-ExtensionTypeName] <String>] [[-ExtensionNoun] <String>] [-RequireCmdletAttribute] [[-OutputPath] <String>] [[-RenameVariable] <IDictionary>] [[-ForeachObject] <ScriptBlock[]>] [[-WhereObject] <ScriptBlock[]>] [<CommonParameters>]
 ```
----
-### Notes
-This returns a modified Get-Extension

--- a/docs/New-Extension.md
+++ b/docs/New-Extension.md
@@ -1,20 +1,36 @@
 New-Extension
 -------------
+
+
+
+
 ### Synopsis
 Creates an Extension
 
+
+
 ---
+
+
 ### Description
 
 Creates an Extension
 
+
+
 ---
+
+
 ### Related Links
 * [Get-Extension](Get-Extension.md)
 
 
 
+
+
 ---
+
+
 ### Examples
 #### EXAMPLE 1
 ```PowerShell
@@ -25,7 +41,11 @@ New-Extension -ExtensionName MyExtension -CommandName New-Extension -ScriptBlock
 }
 ```
 
+
+
 ---
+
+
 ### Parameters
 #### **ExtensionName**
 
@@ -36,25 +56,23 @@ The name of the extension
 
 
 
-|Type      |Required|Position|PipelineInput        |
-|----------|--------|--------|---------------------|
-|`[String]`|false   |1       |true (ByPropertyName)|
+|Type      |Required|Position|PipelineInput        |Aliases|
+|----------|--------|--------|---------------------|-------|
+|`[String]`|false   |1       |true (ByPropertyName)|Name   |
 
 
 
----
 #### **ScriptBlock**
 
 
 
 
-|Type           |Required|Position|PipelineInput        |
-|---------------|--------|--------|---------------------|
-|`[ScriptBlock]`|false   |2       |true (ByPropertyName)|
+|Type           |Required|Position|PipelineInput        |Aliases                      |
+|---------------|--------|--------|---------------------|-----------------------------|
+|`[ScriptBlock]`|false   |2       |true (ByPropertyName)|ScriptContents<br/>Definition|
 
 
 
----
 #### **CommandName**
 
 One or more commands being extended.
@@ -70,7 +88,6 @@ One or more commands being extended.
 
 
 
----
 #### **ExtensionModule**
 
 The extension module.  If provided, this will have to prefix the ExtensionNameRegex
@@ -86,7 +103,6 @@ The extension module.  If provided, this will have to prefix the ExtensionNameRe
 
 
 
----
 #### **ExtensionParameter**
 
 A collection of Extension Parameters.
@@ -103,7 +119,6 @@ The key is the name of the parameter.  The value is any parameter type or attrib
 
 
 
----
 #### **ExtensionParameterHelp**
 
 A collection of Extension Parameter Help.
@@ -119,7 +134,6 @@ A collection of Extension Parameter Help.
 
 
 
----
 #### **ExtensionCommandType**
 
 The type of the extension command.  By default, this is a script.
@@ -143,7 +157,6 @@ Valid Values:
 
 
 
----
 #### **ExtensionSynopsis**
 
 The synopsis used for the extension.
@@ -159,7 +172,6 @@ The synopsis used for the extension.
 
 
 
----
 #### **ExtensionLink**
 
 Any help links for the extension.
@@ -175,7 +187,6 @@ Any help links for the extension.
 
 
 
----
 #### **ExtensionExample**
 
 
@@ -187,11 +198,20 @@ Any help links for the extension.
 
 
 
+
+
 ---
+
+
+### Notes
+At this time, New-Extension assumes that it is not generating an indented script.
+
+
+
+---
+
+
 ### Syntax
 ```PowerShell
 New-Extension [[-ExtensionName] <String>] [[-ScriptBlock] <ScriptBlock>] [[-CommandName] <String[]>] [[-ExtensionModule] <String>] [[-ExtensionParameter] <IDictionary>] [[-ExtensionParameterHelp] <IDictionary>] [[-ExtensionCommandType] <String>] [[-ExtensionSynopsis] <String>] [[-ExtensionLink] <String[]>] [[-ExtensionExample] <String[]>] [<CommonParameters>]
 ```
----
-### Notes
-At this time, New-Extension assumes that it is not generating an indented script.

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,3 +92,4 @@ param(
 $MyEditExtension
 )
 ~~~
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -92,4 +92,3 @@ param(
 $MyEditExtension
 )
 ~~~
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,4 +94,3 @@ param(
 $MyEditExtension
 )
 ~~~
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,3 +94,4 @@ param(
 $MyEditExtension
 )
 ~~~
+


### PR DESCRIPTION
## Piecemeal@0.3.9:

* Allowing any command to be an extension! (Fixes #120)

Functions, Cmdlets, and Aliases that meet the the naming convention will be seen as extensions by Get-Extension.

In most cases, this allows extensions to be defined in memory or on disk.

* Allowing .DisplayName to be set (Fixes #123)
* Adding .CouldPipeType to all extensions (Fixes #121)
* Not allowing a directories to be extensions (for now) (Fixes #125)
* Not clearing an extension's .PSTypeNames (inserting instead) (Fixes #126)

